### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/mpederfte/10da69c1-36bc-4e2b-af2b-b9bda61ea058/96cb3a1d-b65e-45bb-b28d-7b82dbbfa240/_apis/work/boardbadge/b9ae5d12-a6d5-4797-9268-b181603f0955)](https://dev.azure.com/mpederfte/10da69c1-36bc-4e2b-af2b-b9bda61ea058/_boards/board/t/96cb3a1d-b65e-45bb-b28d-7b82dbbfa240/Microsoft.RequirementCategory)
 # azdevopsintegrate


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2118](https://dev.azure.com/mpederfte/10da69c1-36bc-4e2b-af2b-b9bda61ea058/_workitems/edit/2118). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.